### PR TITLE
fix(ProcessRule) : Clone parentObject to prevent error when form data…

### DIFF
--- a/packages/reactive-form-validators/util/app-util.ts
+++ b/packages/reactive-form-validators/util/app-util.ts
@@ -141,4 +141,18 @@ export class ApplicationUtil{
     static lowerCaseWithTrim(value:string) {
         return typeof value === "string" ? value.toLowerCase().trim() : String(value).toLowerCase().trim();
     }
+
+    /** Check if a value is an object */
+    static isObject(value: any): boolean {
+        return Object.prototype.toString.call(value) === '[object Object]';
+    }
+
+    /** Check if a value is an object */
+    static isArray(value: any): boolean {
+        return Array.isArray(value);
+    }
+
+    static cloneValue(value: any): any {
+        return ApplicationUtil.isObject(value) ? ApplicationUtil.isArray(value) ? [...value] : {...value} : value;
+    }
 }

--- a/packages/reactive-form-validators/util/form-provider.ts
+++ b/packages/reactive-form-validators/util/form-provider.ts
@@ -12,7 +12,7 @@ export class FormProvider{
 
     static ProcessRule(control:AbstractControl,config:any,isDynamicConfig:boolean = false) : boolean | {[key:string]:any} {
         const formGroupValue = ApplicationUtil.getParentObjectValue(control);
-        const parentObject = (control.parent) ? control.parent.value : undefined;
+        const parentObject = (control.parent) ? ApplicationUtil.cloneValue(control.parent.value) : undefined;
         let modelInstance = undefined;
         if (control.parent && control.parent instanceof RxFormGroup)
             modelInstance = (<RxFormGroup>control.parent).modelInstance;


### PR DESCRIPTION
… is marked as immutable

To fix error in updateFormControlValue when trying to update parentObject when the value from form was marked by a third party as readonly.
Error when form value object was marked as immutable by a third party or in code. Force rxweb to clone the parent object to not be affected by read only object, as parent object is only for internal use.
Error with akita akita-ng-forms-manager.

Please check if your PR fulfills the following requirements:
* [Commit Guideline](https://rxweb.io/community/commit_guideline)
* [Sending a pull request](https://rxweb.io/community/contributing#sendingapullrequest)
