### PR TITLE
Update allOf.validator.spec.ts

### DIFF
--- a/test/reactive-form-validators/validator/allOf.validator.spec.ts
+++ b/test/reactive-form-validators/validator/allOf.validator.spec.ts
@@ -43,7 +43,7 @@ describe('Validator', () => {
                 qualifications: ['', RxwebValidators.allOf({ matchValues: ["Secondary", "Senior Secondary", "B.Tech", "M.Tech", "B.C.A.", "M.C.A."], conditionalExpression: (x, y) => x.department == 'DotNet' })],
             });
             employeeFormGroup.controls.department.setValue('DotNet');
-            employeeFormGroup.controls.qualifications.setValue(["Secondary", "Senior Secondary", "B.Tech", "M.Tech", "B.C.A.", "M.C.A."]);
+            employeeFormGroup.controls.qualifications.setValue(["Secondary", "Senior Secondary", "B.Tech.", "M.Tech.", "B.C.A.", "M.C.A."]);
             expect(employeeFormGroup.controls.qualifications.errors).toBeNull();
         });
     it("Should not error, allOf validator Conditional Expression with type 'function'",


### PR DESCRIPTION
employeeFormGroup.controls.qualifications.setValue(["Secondary", "Senior Secondary", "B.Tech.", "M.Tech.", "B.C.A.", "M.C.A."]); This line missed dot(.) in B.Tech and M.Tech which makes example not validating.

Please check if your PR fulfills the following requirements:
* [Commit Guideline](https://rxweb.io/community/commit_guideline)
* [Sending a pull request](https://rxweb.io/community/contributing#sendingapullrequest)
