### PR TITLE
Fix validation error with zero values in angular range validator

### DIFF
--- a/client-side/angular/packages/reactive-form-validators/reactive-form-validators/range.validator.ts
+++ b/client-side/angular/packages/reactive-form-validators/reactive-form-validators/range.validator.ts
@@ -12,7 +12,7 @@ export function rangeValidator(configModel: RangeConfig): ValidatorFn {
   return (control: AbstractControl): { [key: string]: any } => {
     let config = getConfigObject(configModel,control,RANGE_CONFIG);
       if (ValidatorValueChecker.pass(control, config)) {
-          if (!(control.value && parseFloat(control.value) >= config.minimumNumber && parseFloat(control.value) <= config.maximumNumber))
+          if (!((control.value != null && control.value != undefined) && parseFloat(control.value) >= config.minimumNumber && parseFloat(control.value) <= config.maximumNumber))
         return ObjectMaker.toJson(AnnotationTypes.range, config, [control.value, config.minimumNumber, config.maximumNumber])
     }
     return ObjectMaker.null();

--- a/client-side/angular/packages/reactive-form-validators/reactive-form-validators/range.validator.ts
+++ b/client-side/angular/packages/reactive-form-validators/reactive-form-validators/range.validator.ts
@@ -12,7 +12,7 @@ export function rangeValidator(configModel: RangeConfig): ValidatorFn {
   return (control: AbstractControl): { [key: string]: any } => {
     let config = getConfigObject(configModel,control,RANGE_CONFIG);
       if (ValidatorValueChecker.pass(control, config)) {
-          if (!((control.value != null && control.value != undefined) && parseFloat(control.value) >= config.minimumNumber && parseFloat(control.value) <= config.maximumNumber))
+          if (!((control.value || control.value === 0) && parseFloat(control.value) >= config.minimumNumber && parseFloat(control.value) <= config.maximumNumber))
         return ObjectMaker.toJson(AnnotationTypes.range, config, [control.value, config.minimumNumber, config.maximumNumber])
     }
     return ObjectMaker.null();

--- a/client-side/angular/test/reactive-form-validators/decorator/range.decorator.spec.ts
+++ b/client-side/angular/test/reactive-form-validators/decorator/range.decorator.spec.ts
@@ -20,6 +20,10 @@ export class EmployeeInfo {
     @numeric({ allowDecimal: true })
     bonus: number;
 
+    @range({ minimumNumber: 0, maximumNumber: 100 })
+    @numeric({ allowDecimal: true })
+    percentageExample: number;
+
 }
 
 
@@ -169,7 +173,13 @@ export class EmployeeInfo {
                 expect(formGroup.controls.bonus.errors).toBeNull();
             });
 
-
+        it('percentageExample should be valid with zero value.',
+            () => {
+            let employeeInfo = new EmployeeInfo();
+            let formGroup = formBuilder.formGroup(employeeInfo);
+            formGroup.controls.percentageExample.setValue(0);
+            expect(formGroup.controls.percentageExample.valid).toEqual(true);
+         });
 
 	//end
     });

--- a/client-side/angular/test/reactive-form-validators/decorator/range.decorator.spec.ts
+++ b/client-side/angular/test/reactive-form-validators/decorator/range.decorator.spec.ts
@@ -173,7 +173,7 @@ export class EmployeeInfo {
                 expect(formGroup.controls.bonus.errors).toBeNull();
             });
 
-        it('percentageExample should be valid with zero value.',
+        it("percentageExample should be valid with zero value.",
             () => {
             let employeeInfo = new EmployeeInfo();
             let formGroup = formBuilder.formGroup(employeeInfo);


### PR DESCRIPTION
Found an issue while using the range validator decorator in our angular application.

Take the scenario where we are trying to validate that a percentage is between 0 and 100 as in the example model below.
If the value is set as 0 in onInit after FormBuilder.formGroup() is called causes a validation error.

Added a test to demonstrate the issue and added a fix in the range validator function to accept zero as a valid value.

```
export class ExampleClass {
    @range({ minimumNumber: 0, maximumNumber: 100, message: 'must be in 0 to 100 range' })
    @numeric({ allowDecimal: true })
    percentageExample: number;
}
```
