### PR TITLE
Fix for #508, reactive-form-validators FormControl.markAsPristine calls wrong super function

### DIFF
--- a/client-side/angular/packages/reactive-form-validators/services/form-control.ts
+++ b/client-side/angular/packages/reactive-form-validators/services/form-control.ts
@@ -238,7 +238,7 @@ export class RxFormControl extends FormControl {
         onlySelf?: boolean;
     }): void {
         let currentState = this.pristine;
-        super.markAsDirty(opts);
+        super.markAsPristine(opts);
         if (currentState != this.pristine)
             this.runControlPropChangeExpression([PRISTINE])
     }


### PR DESCRIPTION
See issue #508 for additional information.