### PR TITLE
fix(types): add missing options to various IFormArray/IFormGroup methods

### DIFF
--- a/client-side/angular/packages/types/reactive-form/i-form-array.ts
+++ b/client-side/angular/packages/types/reactive-form/i-form-array.ts
@@ -4,20 +4,27 @@ import { Observable } from "rxjs";
 export interface IFormArray<Item> extends IAbstractControl<Item[]> {
     controls: IAbstractControl<Item>[];
     getRawValue(): Item[];
-    insert(index: number, control: IAbstractControl<Item>): void;
-    
+    insert(index: number, control: IAbstractControl<Item>, options?: {
+        emitEvent?: boolean;
+    }): void;
 
-    push(control: IAbstractControl<Item>): void;
+    push(control: IAbstractControl<Item>, options?: {
+        emitEvent?: boolean;
+    }): void;
 
-    
-
-    setControl(index: number, control: IAbstractControl<Item>): void;
-    
+    setControl(index: number, control: IAbstractControl<Item>, options?: {
+        emitEvent?: boolean;
+    }): void;
 
     readonly value: Item[];
     readonly valueChanges: Observable<Item[]>;
     at(index: number): IAbstractControl<Item>;
 
-    removeAt(index: number): void;
-    clear(): void
+    removeAt(index: number, options?: {
+        emitEvent?: boolean;
+    }): void;
+    clear(options?: {
+        emitEvent?: boolean;
+    }): void
+    get length(): number;
 }

--- a/client-side/angular/packages/types/reactive-form/i-form-group.ts
+++ b/client-side/angular/packages/types/reactive-form/i-form-group.ts
@@ -6,7 +6,9 @@ export interface IFormGroup<T> extends IAbstractControl<T, T> {
         [key in keyof T]: IAbstractControl<T[key], T>;
     }
 
-    addControl<K extends keyof T>(name: Extract<keyof T, string>, control: AbstractControl | IAbstractControl<T[K]>): void;
+    addControl<K extends keyof T>(name: Extract<keyof T, string>, control: AbstractControl | IAbstractControl<T[K]>, options?: {
+        emitEvent?: boolean;
+    }): void;
 
     contains(controlName: keyof T): boolean;
 
@@ -18,13 +20,17 @@ export interface IFormGroup<T> extends IAbstractControl<T, T> {
     }): void;
 
     registerControl<K extends keyof T>(name: Extract<keyof T, string>, control: AbstractControl | IAbstractControl<T[K]>): AbstractControl;
-    removeControl(name: keyof T): void;
+    removeControl(name: keyof T, options?: {
+        emitEvent?: boolean;
+    }): void;
     reset(value?: T, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
 
-    setControl<K extends keyof T>(name: Extract<keyof T, string>, control: AbstractControl | IAbstractControl<T[K]>): void;
+    setControl<K extends keyof T>(name: Extract<keyof T, string>, control: AbstractControl | IAbstractControl<T[K]>, options?: {
+        emitEvent?: boolean;
+    }): void;
     setValue<K extends keyof T>(value: T, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;


### PR DESCRIPTION
These (optional) options were added in angular 12

Also adds the missing `length` getter for IFormArray