### PR TITLE
Mask custom placeholder #539

### DIFF
--- a/client-side/angular/packages/reactive-form-validators/models/config/mask-config.ts
+++ b/client-side/angular/packages/reactive-form-validators/models/config/mask-config.ts
@@ -3,4 +3,6 @@ export interface MaskConfig extends BaseConfigFn<MaskConfig> {
     mask: string;
     minLength?: number;
     valueWithMask?: boolean;
+    customPlaceholder?: string;
+    clearOnInvalid?: boolean;
 }


### PR DESCRIPTION
### Description

I am using the mask decorator for a date property. The default placeholder character for the mask is \'\_\' is there a way to change that to a custom value like \'mm/dd/yyyy\' instead of '\_\_/\_\_/____', I have a requirement that when the user starts typing the mask should be like this, for example if the user types 3 digits it would be '12/3d/yyyy'. 

### Describe the solution you'd like

Implement two properties for MaskConfig:
- customPlaceholder: string - specify a custom placeholder like 'mm/dd/yyyy' 
- clearOnInvalid: boolean - if true the value is cleared on incomplete value. For example if we start typing a date 12/12/1yyy  and click outside the value will be reverted to the previous value prior focusing.

### Implementation
Edited mask provider to support that. It's a few small changes and I will include a PR following this. Our QA team will thoroughly test this as this will be used on a public ionic app distributed by Apple Store and Google Play. 

This can be used for other mask types besides date.