### PR TITLE
add: messageNexus config option to propObject

### DIFF
--- a/client-side/angular/packages/reactive-form-validators/core/defaultContainer.ts
+++ b/client-side/angular/packages/reactive-form-validators/core/defaultContainer.ts
@@ -132,9 +132,10 @@ export const defaultContainer:
                 dataPropertyName: config ? config.name : undefined,
                 entityProvider: config ? config.entityProvider : undefined,
                 defaultValue:config ? config.defaultValue : undefined,
-                objectConfig:config && config.autoCreate ? {autoCreate:config.autoCreate}: undefined
+                objectConfig:config && config.autoCreate ? {autoCreate:config.autoCreate}: undefined,
+                messageNexus: config ? config.messageNexus : undefined
             }
-            defaultContainer.addProperty(target.constructor, propertyInfo); 
+            defaultContainer.addProperty(target.constructor, propertyInfo);
         }
 
         addInstanceContainer(instanceFunc: any): InstanceContainer {


### PR DESCRIPTION
This PR adds support for the `messageNexus` property in the `@propObject` decorator.

I basically just copied the implementation from `@prop`, since they both call `defaultContainer.addProperty` anyway
